### PR TITLE
Appveyor: Also build applejack branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,6 @@ branches:
   - master
   - applejack
 
-skip_tags: true
 clone_depth: 1
 
 configuration: Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ image: Visual Studio 2019
 branches:
   only:
   - master
+  - applejack
 
 skip_tags: true
 clone_depth: 1


### PR DESCRIPTION
The applejack branch is the aom 2.0.0 release branch. This PR adds it to the aom branches that are build.