### PR TITLE
AppVeyor: Build tags and the applejack branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,8 @@ environment:
 branches:
   only:
   - master
+  - applejack
 
-skip_tags: true
 clone_depth: 1
 
 configuration: Release


### PR DESCRIPTION
 - Builds tags
 - Builds applejack branch

This enables testing of the v2.0.0 release candidates and interim builds. Succeeds #4.